### PR TITLE
Adding page-specific shading (to indicate which tab you're in)

### DIFF
--- a/biomajwatcher/webapp/app/index.html
+++ b/biomajwatcher/webapp/app/index.html
@@ -42,27 +42,27 @@
             </div>
             <div class="navbar-collapse collapse" ng-controller="UserCtrl">
                 <ul class="nav navbar-nav">
-                    <li>
-                        <a href="#/bank" active-link="active">
+                    <li ng-class="bank">
+                        <a id='bank' class="header-label" ng-click="toggleShaded('bank')" href="#/bank" active-link="active">
                             <i class="glyphicon glyphicon-wrench"></i>
                             Banks
                         </a>
                     </li>
-                    <li>
-                        <a href="#/stat">
+                    <li ng-class="stat">
+                        <a id='stat' class="header-label" ng-click="toggleShaded('stat')" href="#/stat">
                             <i class="glyphicon glyphicon-signal"></i>
                             Stats
                         </a>
                     </li>
-                    <li ng-if="is_logged">
-                        <a href="#/schedule">
+                    <li ng-if="is_logged" ng-class="schedule">
+                        <a id="schedule" class="header-label" ng-click="toggleShaded('schedule')" href="#/schedule">
                             <i class="glyphicon glyphicon-time"></i>
                             Schedule
                         </a>
                     </li>
 
-                    <li>
-                        <a href="#/welcome">
+                    <li ng-class="welcome">
+                        <a id="welcome" class="header-label" ng-click="toggleShaded('welcome')" href="#/welcome">
                             <i class="glyphicon glyphicon-question-sign"></i>
                             About
                         </a>

--- a/biomajwatcher/webapp/app/index.html
+++ b/biomajwatcher/webapp/app/index.html
@@ -42,34 +42,34 @@
             </div>
             <div class="navbar-collapse collapse" ng-controller="UserCtrl">
                 <ul class="nav navbar-nav">
-                    <li ng-class="bank">
-                        <a id='bank' class="header-label" ng-click="toggleShaded('bank')" href="#/bank" active-link="active">
+                    <li ng-class="{bank: true, active: isActive('/bank')}">
+                        <a href="#/bank">
                             <i class="glyphicon glyphicon-wrench"></i>
                             Banks
                         </a>
                     </li>
-                    <li ng-class="stat">
-                        <a id='stat' class="header-label" ng-click="toggleShaded('stat')" href="#/stat">
+                    <li ng-class="{stat: true, active: isActive('/stat')}">
+                        <a href="#/stat">
                             <i class="glyphicon glyphicon-signal"></i>
                             Stats
                         </a>
                     </li>
-                    <li ng-if="is_logged" ng-class="schedule">
-                        <a id="schedule" class="header-label" ng-click="toggleShaded('schedule')" href="#/schedule">
+                    <li ng-if="is_logged" ng-class="{schedule: true, active: isActive('/schedule')}">
+                        <a href="#/schedule">
                             <i class="glyphicon glyphicon-time"></i>
                             Schedule
                         </a>
                     </li>
 
-                    <li ng-class="welcome">
-                        <a id="welcome" class="header-label" ng-click="toggleShaded('welcome')" href="#/welcome">
+                    <li ng-class="{welcome: true, active: isActive('/welcome')}">
+                        <a href="#/welcome">
                             <i class="glyphicon glyphicon-question-sign"></i>
                             About
                         </a>
                     </li>
                 </ul>
                 <ul class="nav navbar-nav pull-right">
-                    <li ng-if="! is_logged">
+                    <li ng-if="! is_logged" ng-class="{active: isActive('/login')}">
                         <a href="#/login">
                             <i class="glyphicon glyphicon-user"></i>
                             Login

--- a/biomajwatcher/webapp/app/scripts/biomaj.js
+++ b/biomajwatcher/webapp/app/scripts/biomaj.js
@@ -71,28 +71,12 @@ angular.module('biomaj').controller('biomajCtrl', ['$scope', '$rootScope', '$loc
         $rootScope.closeAlert = function (index) {
             $rootScope.alerts.splice(index, 1);
         };
-        $rootScope.toggleShaded = function(elementId){
-
-            $scope.elements = document.getElementsByClassName("header-label");
-            var len = $scope.elements.length;
-
-            for (var i = 0; i<len; i++){
-              if($scope.elements[i].getAttribute("id") == elementId){
-                $scope.elements[i].style.backgroundColor = '#ffffff';
-                $scope.elements[i].style.color = '#000000';
-              }
-              else{
-                $scope.elements[i].style.backgroundColor = '#222222';
-                $scope.elements[i].style.color = '#999999';
-              }
-            }
-
-            if ($location.path() == '/bank'){
-
-
-            } else {
-
-            }
+        $rootScope.isActive = function(path){
+          if ($location.path().substr(0, path.length) === path) {
+            return true;
+          } else {
+            return false;
+          }
         };
     }]);
 

--- a/biomajwatcher/webapp/app/scripts/biomaj.js
+++ b/biomajwatcher/webapp/app/scripts/biomaj.js
@@ -64,13 +64,37 @@ angular.module('biomaj').controller('WelcomeCtrl',
     function () {});
 
 
-angular.module('biomaj').controller('biomajCtrl',
-    function ($rootScope) {
+angular.module('biomaj').controller('biomajCtrl', ['$scope', '$rootScope', '$location',
+    function ($scope, $rootScope, $location) {
         $rootScope.alerts = [];
+        $rootScope.elements = [];
         $rootScope.closeAlert = function (index) {
             $rootScope.alerts.splice(index, 1);
         };
-    });
+        $rootScope.toggleShaded = function(elementId){
+
+            $scope.elements = document.getElementsByClassName("header-label");
+            var len = $scope.elements.length;
+
+            for (var i = 0; i<len; i++){
+              if($scope.elements[i].getAttribute("id") == elementId){
+                $scope.elements[i].style.backgroundColor = '#ffffff';
+                $scope.elements[i].style.color = '#000000';
+              }
+              else{
+                $scope.elements[i].style.backgroundColor = '#222222';
+                $scope.elements[i].style.color = '#999999';
+              }
+            }
+
+            if ($location.path() == '/bank'){
+
+
+            } else {
+
+            }
+        };
+    }]);
 
 angular.module('biomaj').controller('scheduleCtrl',
     function ($scope, $rootScope, $routeParams, $log, $location, Bank, User, Auth, Schedule) {


### PR DESCRIPTION
update of pull request #10 

Hey guys, 

We made some edits to the original request to make this cleaner and more universal. It'll work with the stock theme and editing the shading is as simple as modifying the CSS for :active for the buttons. Additionally, we made the highlight more reliable; it'll stay on when editing bank information, for example, and it'll more reliably highlight the appropriate link for the current parent in the URL.

Here's what it looks like: 

Banks/Homepage:
![screenshot from 2015-09-10 10 07 01](https://cloud.githubusercontent.com/assets/14098761/9792195/7febe094-57a4-11e5-9c7f-cc9671e608b6.png)

Stats:
![screenshot from 2015-09-10 10 07 23](https://cloud.githubusercontent.com/assets/14098761/9792198/830be2e2-57a4-11e5-9f5a-25af3d1269e3.png)

Schedule:
![screenshot from 2015-09-10 10 07 33](https://cloud.githubusercontent.com/assets/14098761/9792201/8586efc6-57a4-11e5-8059-f4f717e2f36a.png)

About:
![screenshot from 2015-09-10 10 07 49](https://cloud.githubusercontent.com/assets/14098761/9792203/88860ee6-57a4-11e5-836d-ca60b59b1fae.png)

Thanks!
